### PR TITLE
Corrected typo

### DIFF
--- a/src/epub/text/chapter-11.xhtml
+++ b/src/epub/text/chapter-11.xhtml
@@ -83,7 +83,7 @@
 			<p>Sir Clinton hastened to reassure him.</p>
 			<p>“I’m not going to poke fun at you merely for the sake of making you uncomfortable, Squire. It would really be some help if I could see the thing from a fresh point of view. Lord knows, I’m not infallible; and you may quite easily hit on something that’ll put a new light on things and prevent me making a bad mistake.”</p>
 			<p>The obvious sincerity of this was enough to placate Wendover. He had been cogitating deeply over the Whistlefield affair, and he felt that if he could not suggest a provable solution of the mystery, at least he could bring a reasonable amount of criticism to bear on the available evidence.</p>
-			<p>“What we have to account for,” he began, “are; first, the murder of the two Shandons; second, the burglary; third, the attack on Ernest Shandon; and, fourth, the so-called hanky-panky with the cheque.”</p>
+			<p>“What we have to account for,” he began, “are: first, the murder of the two Shandons; second, the burglary; third, the attack on Ernest Shandon; and, fourth, the so-called hanky-panky with the cheque.”</p>
 			<p>“That’s correct,” Sir Clinton agreed. “But suppose we leave out the cheque affair at present. We really know nothing definite about it yet.”</p>
 			<p>Wendover was dissatisfied with this ruling.</p>
 			<p>“It seems to me an essential part in the scheme of things. Let me put the case as I see it. Hackleton is at the back of the whole affair, I take it; but he’s been employing an agent; and that agent has been going beyond Hackleton’s instructions and has been operating on his own to a certain extent. I think that fits everything in the case.”</p>


### PR DESCRIPTION
Source: https://archive.org/details/dli.ernet.242618/page/107/mode/2up?q=%22first%2C+the+murder%22

In the same linked page above, in the same quote, there's also a possible colon rather than a semicolon after "two Shandons", but I don't think a colon makes sense there and that might just be a scan error (so I omitted it).